### PR TITLE
Fix Shellcheck Warnings

### DIFF
--- a/compiling/extract_and_compile.sh
+++ b/compiling/extract_and_compile.sh
@@ -6,8 +6,8 @@ INT=$1
 
 tar -zxf NthPrime.tgz
 
-# Go into the NthPrime directory created by the tar command
-cd NthPrime
+# Go into the NthPrime directory created by the tar command or exit if the cd fails
+cd NthPrime || exit
 
 # Compile and combine the c files in the NthPrime directory to form the executable name NthPrime
 gcc  main.c nth_prime.c -o NthPrime


### PR DESCRIPTION
This commit addresses the warnings that shellcheck was giving for the extract_and_compile.sh script

Co-authored-by: Dante Miller <mill8622@morris.umn.edu>